### PR TITLE
Include fb303_scripts

### DIFF
--- a/fb303_scripts/__init__.py
+++ b/fb303_scripts/__init__.py
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+__all__ = ['fb303_simple_mgmt']

--- a/fb303_scripts/fb303_simple_mgmt.py
+++ b/fb303_scripts/fb303_simple_mgmt.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import sys, os
+from optparse import OptionParser
+
+from thrift.Thrift import *
+
+from thrift.transport import TSocket
+from thrift.transport import TTransport
+from thrift.protocol import TBinaryProtocol
+
+from fb303 import *
+from fb303.ttypes import *
+
+def service_ctrl(
+                 command,
+                 port,
+                 trans_factory = None,
+                 prot_factory = None):
+    """
+    service_ctrl is a generic function to execute standard fb303 functions
+
+    @param command: one of stop, start, reload, status, counters, name, alive
+    @param port: service's port
+    @param trans_factory: TTransportFactory to use for obtaining a TTransport. Default is
+                          TBufferedTransportFactory
+    @param prot_factory: TProtocolFactory to use for obtaining a TProtocol. Default is
+                         TBinaryProtocolFactory
+    """
+
+    if command in ["status"]:
+        try:
+            status = fb303_wrapper('status', port, trans_factory, prot_factory)
+            status_details = fb303_wrapper('get_status_details', port, trans_factory, prot_factory)
+
+            msg = fb_status_string(status)
+            if (len(status_details)):
+                msg += " - %s" % status_details
+            print msg
+
+            if (status == fb_status.ALIVE):
+                return 2
+            else:
+                return 3
+        except:
+            print "Failed to get status"
+            return 3
+
+    # scalar commands
+    if command in ["version","alive","name"]:
+        try:
+            result = fb303_wrapper(command,  port, trans_factory, prot_factory)
+            print result
+            return 0
+        except:
+            print "failed to get ",command
+            return 3
+
+    # counters
+    if command in ["counters"]:
+        try:
+            counters = fb303_wrapper('counters',  port, trans_factory, prot_factory)
+            for counter in counters:
+                print "%s: %d" % (counter, counters[counter])
+            return 0
+        except:
+            print "failed to get counters"
+            return 3
+
+
+    # Only root should be able to run the following commands
+    if os.getuid() == 0:
+        # async commands
+        if command in ["stop","reload"] :
+            try:
+                fb303_wrapper(command, port, trans_factory, prot_factory)
+                return 0
+            except:
+                print "failed to tell the service to ", command
+                return 3
+    else:
+        if command in ["stop","reload"]:
+            print "root privileges are required to stop or reload the service."
+            return 4
+
+    print "The following commands are available:"
+    for command in ["counters","name","version","alive","status"]:
+        print "\t%s" % command
+    print "The following commands are available for users with root privileges:"
+    for command in ["stop","reload"]:
+        print "\t%s" % command
+
+
+
+    return 0;
+
+
+def fb303_wrapper(command, port, trans_factory = None, prot_factory = None):
+    sock = TSocket.TSocket('localhost', port)
+
+    # use input transport factory if provided
+    if (trans_factory is None):
+        trans = TTransport.TBufferedTransport(sock)
+    else:
+        trans = trans_factory.getTransport(sock)
+
+    # use input protocol factory if provided
+    if (prot_factory is None):
+        prot = TBinaryProtocol.TBinaryProtocol(trans)
+    else:
+        prot = prot_factory.getProtocol(trans)
+
+    # initialize client and open transport
+    fb303_client = FacebookService.Client(prot, prot)
+    trans.open()
+
+    if (command == 'reload'):
+        fb303_client.reinitialize()
+
+    elif (command == 'stop'):
+        fb303_client.shutdown()
+
+    elif (command == 'status'):
+        return fb303_client.getStatus()
+
+    elif (command == 'version'):
+        return fb303_client.getVersion()
+
+    elif (command == 'get_status_details'):
+        return fb303_client.getStatusDetails()
+
+    elif (command == 'counters'):
+        return fb303_client.getCounters()
+
+    elif (command == 'name'):
+        return fb303_client.getName()
+
+    elif (command == 'alive'):
+        return fb303_client.aliveSince()
+
+    trans.close()
+
+
+def fb_status_string(status_enum):
+    if (status_enum == fb_status.DEAD):
+        return "DEAD"
+    if (status_enum == fb_status.STARTING):
+        return "STARTING"
+    if (status_enum == fb_status.ALIVE):
+        return "ALIVE"
+    if (status_enum == fb_status.STOPPING):
+        return "STOPPING"
+    if (status_enum == fb_status.STOPPED):
+        return "STOPPED"
+    if (status_enum == fb_status.WARNING):
+        return "WARNING"
+
+
+def main():
+
+    # parse command line options
+    parser = OptionParser()
+    commands=["stop","counters","status","reload","version","name","alive"]
+
+    parser.add_option("-c", "--command", dest="command", help="execute this API",
+                      choices=commands, default="status")
+    parser.add_option("-p","--port",dest="port",help="the service's port",
+                      default=9082)
+
+    (options, args) = parser.parse_args()
+    status = service_ctrl(options.command, options.port)
+    sys.exit(status)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/scribe_cat
+++ b/scripts/scribe_cat
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+##  Copyright (c) 2007-2008 Facebook
+##
+##  Licensed under the Apache License, Version 2.0 (the "License");
+##  you may not use this file except in compliance with the License.
+##  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+## See accompanying file LICENSE or visit the Scribe site at:
+## http://developers.facebook.com/scribe/
+
+
+'''scribe_cat: A simple script for sending messages to scribe.'''
+
+import sys
+from scribe import scribe
+from thrift.transport import TTransport, TSocket
+from thrift.protocol import TBinaryProtocol
+
+if len(sys.argv) == 2:
+  category = sys.argv[1]
+  host = '127.0.0.1'
+  port = 1463
+elif len(sys.argv) == 4 and sys.argv[1] == '-h':
+  category = sys.argv[3]
+  host_port = sys.argv[2].split(':')
+  host = host_port[0]
+  if len(host_port) > 1:
+    port = int(host_port[1])
+  else:
+    port = 1463
+else:
+  sys.exit('usage (message is stdin): scribe_cat [-h host[:port]] category')
+
+log_entry = scribe.LogEntry(category=category, message=sys.stdin.read())
+
+socket = TSocket.TSocket(host=host, port=port)
+transport = TTransport.TFramedTransport(socket)
+protocol = TBinaryProtocol.TBinaryProtocol(trans=transport, strictRead=False, strictWrite=False)
+client = scribe.Client(iprot=protocol, oprot=protocol)
+
+transport.open()
+result = client.Log(messages=[log_entry])
+transport.close()
+
+if result == scribe.ResultCode.OK:
+  sys.exit()
+elif result == scribe.ResultCode.TRY_LATER:
+  print >> sys.stderr, "TRY_LATER"
+  sys.exit(84)  # 'T'
+else:
+  sys.exit("Unknown error code.")

--- a/scripts/scribe_ctrl
+++ b/scripts/scribe_ctrl
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+##  Copyright (c) 2007-2008 Facebook
+##
+##  Licensed under the Apache License, Version 2.0 (the "License");
+##  you may not use this file except in compliance with the License.
+##  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+##
+## See accompanying file LICENSE or visit the Scribe site at:
+## http://developers.facebook.com/scribe/
+
+'''scribe_ctrl: A simple script for running and monitoring scribe.'''
+
+import sys
+
+#make this work for facebook environment too
+isFacebook = 0
+if (isFacebook == 1):
+    # put your own path here!
+    sys.path.insert(0, '/mytrunk/fbcode-test/common/fb303/scripts')
+    import fb303_simple_mgmt
+else:
+    from fb303_scripts import *
+
+# thrift python packages need to be installed
+import thrift
+from thrift import protocol, transport
+from thrift.transport import TTransport
+from thrift.protocol import TBinaryProtocol
+
+if (len(sys.argv) > 2):
+    port = int(sys.argv[2])
+else:
+    port = 1463
+
+if (len(sys.argv) > 1):
+    retval = fb303_simple_mgmt.service_ctrl(sys.argv[1],
+                                            port,
+                                            trans_factory = TTransport.TFramedTransportFactory(),
+                                            prot_factory = TBinaryProtocol.TBinaryProtocolFactory())
+    sys.exit(retval)
+
+else:
+    print 'Usage: scribe_ctrl command [port]'
+    print '  commands: stop counters status version name alive'
+    sys.exit(2)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name='facebook-scribe',
       author_email='tom.primozic@zemanta.com',
       description='A Python client for Facebook Scribe',
       long_description=__doc__,
-      packages=['fb303', 'scribe'],
+      packages=['fb303','fb303_scripts', 'scribe'],
+      scripts=['scripts/scribe_cat', 'scripts/scribe_ctrl'],
       install_requires=['thrift>=0.9.0'],
 )


### PR DESCRIPTION
Installing fb303 via the thrift source includes 'fb303_scripts'. The
distributed python module should also install them.
