### PR TITLE
Change the import of ttypes for compatibility with Python3 imports

### DIFF
--- a/fb303/FacebookService.py
+++ b/fb303/FacebookService.py
@@ -5,9 +5,9 @@
 #
 #  options string: py
 #
-
+from __future__ import absolute_import
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
-from ttypes import *
+from .ttypes import *
 from thrift.Thrift import TProcessor
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol

--- a/scribe/scribe.py
+++ b/scribe/scribe.py
@@ -5,10 +5,10 @@
 #
 #  options string: py
 #
-
+from __future__ import absolute_import
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import fb303.FacebookService
-from ttypes import *
+from .ttypes import *
 from thrift.Thrift import TProcessor
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol


### PR DESCRIPTION
Relative imports have to be explicit in recent versions of Python. 

Currently, when installing your package for Python 3, 2to3 misses this necessary change. The fix is these simple 4 lines of code.